### PR TITLE
Replace prints with logging

### DIFF
--- a/ffprobe_utils.py
+++ b/ffprobe_utils.py
@@ -4,8 +4,11 @@ import subprocess
 import shutil
 from typing import Optional, Dict, Any
 import imageio_ffmpeg
+from logger_config import get_logger
 
 FFMPEG_BINARY = imageio_ffmpeg.get_ffmpeg_exe()
+
+logger = get_logger(__name__)
 
 
 def get_ffprobe_path() -> Optional[str]:
@@ -18,16 +21,16 @@ def get_ffprobe_path() -> Optional[str]:
         ffmpeg_path = FFMPEG_BINARY
         ffprobe_path = os.path.join(os.path.dirname(ffmpeg_path), "ffprobe")
         if os.path.exists(ffprobe_path):
-            print(f"[INFO] ffprobe found at {ffprobe_path}")
+            logger.info("ffprobe found at %s", ffprobe_path)
             return ffprobe_path
         ffprobe_path = shutil.which("ffprobe")
         if ffprobe_path:
-            print(f"[INFO] ffprobe found in PATH at {ffprobe_path}")
+            logger.info("ffprobe found in PATH at %s", ffprobe_path)
             return ffprobe_path
-        print("[ERROR] ffprobe not found in FFMPEG directory or system PATH")
+        logger.error("ffprobe not found in FFMPEG directory or system PATH")
         return None
     except OSError as e:
-        print(f"[ERROR] Failed to locate ffprobe: {e}")
+        logger.error("Failed to locate ffprobe: %s", e)
         return None
 
 
@@ -43,18 +46,18 @@ def run_ffprobe(ffprobe_path: str, args: list[str], video_path: str) -> Optional
         Optional[Dict[str, Any]]: Parsed JSON output or None if failed.
     """
     if not ffprobe_path:
-        print("[ERROR] Cannot run ffprobe: binary not available")
+        logger.error("Cannot run ffprobe: binary not available")
         return None
     try:
         cmd = [ffprobe_path, "-loglevel", "error"] + args + ["-of", "json", video_path]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
         return json.loads(result.stdout)
     except subprocess.CalledProcessError as e:
-        print(f"[ERROR] ffprobe command failed: {e}")
+        logger.error("ffprobe command failed: %s", e)
         return None
     except json.JSONDecodeError as e:
-        print(f"[ERROR] Failed to parse ffprobe output: {e}")
+        logger.error("Failed to parse ffprobe output: %s", e)
         return None
     except OSError as e:
-        print(f"[ERROR] Failed to execute ffprobe: {e}")
+        logger.error("Failed to execute ffprobe: %s", e)
         return None

--- a/logger_config.py
+++ b/logger_config.py
@@ -1,0 +1,7 @@
+import logging
+
+def get_logger(name: str = __name__) -> logging.Logger:
+    if not logging.getLogger().hasHandlers():
+        logging.basicConfig(level=logging.INFO,
+                            format="%(asctime)s - %(levelname)s - %(message)s")
+    return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- introduce `logger_config` helper
- replace print statements with logging in `export_part`, `ffprobe_utils` and `instavideosplitter`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68499d6e4d78832abe91b34269b6aa99