### PR TITLE
Fix undefined audio constants

### DIFF
--- a/instavideosplitter.py
+++ b/instavideosplitter.py
@@ -8,6 +8,13 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import imageio_ffmpeg
 import moviepy.config as mpy_config
 from ffprobe_utils import get_ffprobe_path, run_ffprobe
+from export_part import (
+    AUDIO_CODEC,
+    AUDIO_BITRATE,
+    PRESET,
+    THREADS,
+    AUDIO_CHANNELS,
+)
 from typing import Tuple, Optional, Dict, Any, List
 
 # Constants for configuration


### PR DESCRIPTION
## Summary
- import audio export constants in `instavideosplitter.py`
- confirm no more undefined-name errors via `ruff`

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6849aef5fb6c832abe0fc21479746e25