### PR TITLE
Clean up ffmpeg_config duplicates

### DIFF
--- a/ffmpeg_config.py
+++ b/ffmpeg_config.py
@@ -40,36 +40,3 @@ def get_ffmpeg_path() -> str:
     """Get the full path to the ffmpeg executable."""
     return os.path.join(_ffmpeg_dir, "ffmpeg")
 
-
-import os
-import imageio_ffmpeg
-import moviepy.config as mpy_config
-
-_ffmpeg_dir = os.path.dirname(imageio_ffmpeg.get_ffmpeg_exe())
-mpy_config.change_settings({"FFMPEG_BINARY": os.path.join(_ffmpeg_dir, "ffmpeg")})
-
-
-def set_ffmpeg_dir(path: str) -> None:
-    """Set the directory containing the ffmpeg binaries."""
-    global _ffmpeg_dir
-    if path:
-        _ffmpeg_dir = path
-        mpy_config.change_settings({"FFMPEG_BINARY": os.path.join(_ffmpeg_dir, "ffmpeg")})
-
-
-def set_ffmpeg_path(path: str) -> None:
-    """Compatibility wrapper: accept a binary path or directory."""
-    if path and not os.path.isdir(path):
-        path = os.path.dirname(path)
-    set_ffmpeg_dir(path)
-
-
-def get_ffmpeg_dir() -> str:
-    """Get the directory containing ffmpeg binaries."""
-    return _ffmpeg_dir
-
-
-def get_ffmpeg_path() -> str:
-    """Get the full path to the ffmpeg executable."""
-    return os.path.join(_ffmpeg_dir, "ffmpeg")
-


### PR DESCRIPTION
## Summary
- remove duplicated ffmpeg helper functions so only one set remains

## Testing
- `python -m py_compile $(find . -name '*.py')`
- `python - <<'PY'
import ffmpeg_config
print('ffmpeg path:', ffmpeg_config.get_ffmpeg_path())
PY`


------
https://chatgpt.com/codex/tasks/task_e_684a64f91a10832a870fed6d6edfd0c2