### PR TITLE
Ignore ffmpeg stdout in export_part

### DIFF
--- a/instavideosplitter.py
+++ b/instavideosplitter.py
@@ -91,7 +91,7 @@ def export_part(video_path: str, start_time: float, end_time: float, output_path
     ]
 
     try:
-        subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
         return output_path, True, None
     except subprocess.CalledProcessError as e:
         error_msg = e.stderr.decode() if e.stderr else str(e)


### PR DESCRIPTION
## Summary
- discard ffmpeg's stdout when exporting video segments to avoid unnecessary buffering

## Testing
- `python -m py_compile instavideosplitter.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0a9a9b39c832a97b071e6653784d2