### PR TITLE
Track and return successful video splits

### DIFF
--- a/instavideosplitter_gui.py
+++ b/instavideosplitter_gui.py
@@ -158,7 +158,7 @@ class VideoSplitterApp(customtkinter.CTk):
         try:
             self.progress.set(0)
             self.status_label.configure(text="Processing...")
-            num_parts = trim_video_to_parts(
+            completed_parts = trim_video_to_parts(
                 self.file_path,
                 self.output_dir,
                 self.update_progress,
@@ -167,8 +167,8 @@ class VideoSplitterApp(customtkinter.CTk):
                 ask_allow_long_last_part=self.ask_allow_longer
             )
             self.progress.set(1)
-            self.status_label.configure(text=f"Done: Trimmed into {num_parts} parts.")
-            messagebox.showinfo("Success", f"Trimmed into {num_parts} parts.")
+            self.status_label.configure(text=f"Done: Trimmed into {completed_parts} parts.")
+            messagebox.showinfo("Success", f"Trimmed into {completed_parts} parts.")
             self.open_output_folder()
         except Exception as e:
             self.status_label.configure(text="Error occurred.")


### PR DESCRIPTION
## Summary
- Only count successfully exported segments when trimming videos
- Raise an error on export failures and report accurate segment count
- Update GUI messages to use the new completion count

## Testing
- `python -m py_compile instavideosplitter.py instavideosplitter_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0b9247864832aa23144f332712a66